### PR TITLE
초기 테스트 코드 및 테스트 환경 설정

### DIFF
--- a/backend/tests/integration/test_server.py
+++ b/backend/tests/integration/test_server.py
@@ -1,0 +1,19 @@
+import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from app import app
+
+class ServerIntegrationTests(unittest.TestCase):
+    def setUp(self):
+        self.app = app.test_client()
+        self.app.testing = True
+
+    def test_server_running(self):
+        response = self.app.get('/')
+        self.assertEqual(response.status_code, 200)
+    
+    def test_static_files(self):
+	pass

--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -1,0 +1,6 @@
+{
+  "baseUrl": "http://localhost:3000",
+  "integrationFolder": "cypress/integration",
+  "fixturesFolder": "cypress/fixtures",
+  "supportFile": "cypress/support/index.js"
+}

--- a/frontend/cypress/integration/app_spec.js
+++ b/frontend/cypress/integration/app_spec.js
@@ -1,0 +1,20 @@
+describe('Audio Transcription App', () => {
+  it('should load the homepage', () => {
+    cy.visit('/');
+    cy.contains('음성 인식 애플리케이션').should('be.visible');
+  });
+  
+  it('should have recording buttons', () => {
+    cy.visit('/');
+    cy.contains('녹음 시작').should('be.visible');
+    cy.contains('녹음 중지').should('be.visible');
+  });
+  
+  it('should update UI when recording starts and stops', () => {
+    cy.visit('/');
+    cy.contains('녹음 시작').click();
+    cy.contains('녹음이 시작되었습니다.').should('be.visible');
+    cy.contains('녹음 중지').click();
+    cy.contains('녹음이 중지되었습니다.').should('be.visible');
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "devDependencies": {
+    "cypress": "^9.7.0"
+  }
+"scripts": {
+  "start": "react-scripts start",
+  "build": "react-scripts build",
+  "test": "react-scripts test",
+  "eject": "react-scripts eject",
+  "cy:open": "cypress open",
+  "cy:run": "cypress run"
+}
+}
+


### PR DESCRIPTION
## 변경 사항
- 백엔드 통합 테스트 코드 추가
- 프론트엔드 E2E 테스트를 위한 Cypress 설정
- 기본 E2E 테스트 케이스 작성

## 테스트 방법
1. 백엔드 테스트: `cd backend && python -m unittest discover tests`
2. 프론트엔드 유닛 테스트: `cd frontend && npm test`
3. 프론트엔드 E2E 테스트: `cd frontend && npm run cy:open`

// Ilyas, you were supposed to create a repository in the class organization. You should ask the professor about this.